### PR TITLE
adding angular-gist-embed ref to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 #### Other ways to use gist-embed
 ##### Ruby Gem
 @itsNikolay Has created an easy to use ruby gem for gist-embed, you can find it here: https://github.com/itsNikolay/gist-embed-rails
+##### AngularJs
+Small library created to ease the use of gist-embed in your angular projects: https://github.com/pasupulaphani/angular-gist-embed
 
 ####Examples
 See http://blairvanderhoof.com/gist-embed/ for all possible ways to use gist-embed:


### PR DESCRIPTION
Hi Blair, I like your solution gist-embed and have been using it for long time. Recently I wanted to use it in an AngularJs project. As usual it worked brilliantly but needed to trigger gist() on newly rendered dom when used with dynamic templates.

So, I've created https://github.com/pasupulaphani/angular-gist-embed, to make it easy to use in angular projects.

If you are happy with the work please accept the pull request to reference angular-gist-embed in your README.md.

Kind regards,
Phani.