### PR TITLE
Basic strict mode compliance

### DIFF
--- a/gist-embed.js
+++ b/gist-embed.js
@@ -2,6 +2,7 @@
 // https://github.com/blairvanderhoof/gist-embed
 // version 2.3
 (function($) {
+  'use strict';
 
   function getLineNumbers(lineRangeString) {
     var lineNumbers = [], range, lineNumberSections;
@@ -38,6 +39,7 @@
         showLoading,
         showSpinner,
         data = {};
+      var loading;
 
       // make block level so loading text shows properly
       $elem.css('display', 'block');

--- a/gist-embed.js
+++ b/gist-embed.js
@@ -33,13 +33,13 @@
         url,
         file,
         lines,
+        loading,
         highlightLines,
         hideFooterOption,
         hideLineNumbersOption,
         showLoading,
         showSpinner,
         data = {};
-      var loading;
 
       // make block level so loading text shows properly
       $elem.css('display', 'block');


### PR DESCRIPTION
Basic strict mode compliance - basically an `use strict;` statement and preventing definition of a global variable (which even without strict mode is generally bad practice, and definitely unnecessary here).